### PR TITLE
Add toggle to MobileMenu

### DIFF
--- a/addon/components/mobile-menu.hbs
+++ b/addon/components/mobile-menu.hbs
@@ -44,6 +44,7 @@
           actions=(hash
             open=this.open
             close=this.close
+            toggle=this.openOrClose
           )
         )
       }}


### PR DESCRIPTION
Use case: keyboard shortcuts! :D 

```hbs
<MobileMenuWrapper @openDetectonWidth={{30}} as |mmw|>

  {{#if this.currentUser.isLoggedIn}}
    <mmw.MobileMenu
      @isOpen={{this.sidebar.isOpen}}
      @onToggle={{this.sidebar.toggle}}
    as |mm|>

      <App::Sidebar
        class='sidebar-wrapper'
        id='sidebar'
        {{on-key 'ctrl+space' this.sidebar.toggle}}
      />

    </mmw.MobileMenu>
  {{/if}}

  <mmw.Content>
    {{yield}}
  </mmw.Content>
</MobileMenuWrapper>
```