### PR TITLE
remove old service re-export (fixes embroider build)

### DIFF
--- a/app/services/mobile-menu.js
+++ b/app/services/mobile-menu.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-mobile-menu/services/mobile-menu';


### PR DESCRIPTION
Cleanup of 46efffcd4014bbc1bd14cffc33bc3bee3b049fa5 fixes build error when building with embroider ([log from travis](https://travis-ci.org/github/nickschot/ember-mobile-menu/jobs/735412013#L360)):

```
Build Error (PackagerRunner)

Module not found: Error: Can't resolve '../node_modules/ember-mobile-menu/services/mobile-menu' in '/private/var/folders/d6/mxwlnyds65dgg3pkb8kzgxzw0000gn/T/embroider/c07010/services'
```

