### PR TITLE
put splattributes on the Tray instead of the (less useful) wrapper div of the MobileMenu component

### DIFF
--- a/addon/components/mobile-menu.hbs
+++ b/addon/components/mobile-menu.hbs
@@ -7,7 +7,6 @@
     {{did-update (fn this.openOrClose @isOpen) @isOpen}}
     {{did-update this.close this.type}}
     aria-hidden={{if this.state.closed "true"}}
-    ...attributes
   >
     {{#if this.maskEnabled}}
       <MobileMenu::Mask
@@ -25,6 +24,8 @@
     {{/if}}
 
     <MobileMenu::Tray
+      ...attributes
+
       @width={{this._width}}
       @isLeft={{this.isLeft}}
       @position={{this.position}}


### PR DESCRIPTION
fixes #96 