### PR TITLE
don't initialize body scroll when in fastboot

### DIFF
--- a/addon/components/mobile-menu/tray.js
+++ b/addon/components/mobile-menu/tray.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { getOwner } from '@ember/application';
 import { htmlSafe } from '@ember/string';
 import { action } from '@ember/object';
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
@@ -13,6 +14,11 @@ import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
  * @hide
  */
 export default class TrayComponent extends Component {
+  fastboot = getOwner(this).lookup('service:fastboot');
+  get isFastBoot() {
+    return !!this.fastboot?.isFastBoot;
+  }
+
   /**
    * Width of the menu in px.
    *
@@ -83,7 +89,7 @@ export default class TrayComponent extends Component {
 
   @action
   toggleBodyScroll(target, [isClosed]) {
-    if (this.args.preventScroll && !this.args.embed) {
+    if (this.args.preventScroll && !this.args.embed && !this.isFastBoot) {
       if (isClosed) {
         enableBodyScroll(target);
       } else {


### PR DESCRIPTION
This PR addresses a " TypeError: window.addEventListener is not a function" error when using ember-mobile-menu under fastboot by preventing the body-scroll-lock library from initializing when running on the server where window isn't defined.

Error & start of stack trace...
```
There was an error running your app in fastboot. More info about the error: 
 TypeError: window.addEventListener is not a function
    at eval (webpack://__ember_auto_import__/./node_modules/body-scroll-lock/lib/bodyScrollLock.esm.js?:10:147)
    at Module../node_modules/body-scroll-lock/lib/bodyScrollLock.esm.js....
```

Fixes #186 

