### PR TITLE
fix for ember 4

### DIFF
--- a/addon/components/mobile-menu/link-to.hbs
+++ b/addon/components/mobile-menu/link-to.hbs
@@ -1,0 +1,11 @@
+<LinkTo
+  @route={{@route}}
+  @disabled={{@disabled}}
+  @current-when={{@current-when}}
+  @models={{this.models}}
+  @query={{this.query}}
+  {{on "click" this.click}}
+  ...attributes
+>
+  {{yield}}
+</LinkTo>

--- a/addon/components/mobile-menu/link-to.js
+++ b/addon/components/mobile-menu/link-to.js
@@ -1,5 +1,5 @@
-/* eslint-disable ember/no-classic-classes, ember/no-component-lifecycle-hooks */
-import { LinkComponent } from '@ember/legacy-built-in-components';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 /**
  * An extended LinkTo component which provides an onClick hook.
@@ -7,23 +7,23 @@ import { LinkComponent } from '@ember/legacy-built-in-components';
  * @class LinkTo
  * @public
  */
-export default LinkComponent.extend({
-  didReceiveAttrs() {
-    this._super(...arguments);
+export default class LinkToComponent extends Component {
+  get models() {
+    if (this.args.models) {
+      return this.args.models;
+    }
+    if (this.args.model) {
+      return [this.args.model];
+    }
+    return [];
+  }
 
-    this.set('current-when', this.qualifiedRouteName);
-  },
+  get query() {
+    return this.args.query || {};
+  }
 
-  /**
-   * Hook called when the link is clicked.
-   *
-   * @argument onClick
-   * @type function
-   * @default function(){}
-   */
-  onClick() {},
-
+  @action
   click() {
-    this.onClick();
-  },
-});
+    this.args?.onClick();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prepare": "node ./compile-css.js"
   },
   "dependencies": {
-    "@ember/legacy-built-in-components": "^0.4.0",
     "@ember/render-modifiers": "^2.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",


### PR DESCRIPTION
This is a try to fix compatibility with ember 4. Especially this removes `@ember/legacy-built-in-components`.
For this I basically completely changed the special `<LinkTo` component to not extend the built-in component but instead proxy it.