### PR TITLE
protect against using window apis in Fastboot

### DIFF
--- a/addon/components/mobile-menu/tray.js
+++ b/addon/components/mobile-menu/tray.js
@@ -79,7 +79,7 @@ export default class TrayComponent extends Component {
 
   @action
   toggleBodyScroll(target, [isClosed]) {
-    if (this.args.preventScroll && !this.args.embed) {
+    if (this.args.preventScroll && !this.args.embed && typeof FastBoot === 'undefined') {
       if (isClosed) {
         enableBodyScroll(target);
       } else {


### PR DESCRIPTION
You can't call `window.setEventListener` when you're in a fastboot environment so you need to just guard those places in the code 👍 