### PR TITLE
Fix fastboot compatibility and add smoke test

### DIFF
--- a/addon/addon/components/mobile-menu/tray.js
+++ b/addon/addon/components/mobile-menu/tray.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { action } from '@ember/object';
-import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
+import { task } from 'ember-concurrency';
 
 /**
  * The tray that resides within the menu. Menu content is placed in here.
@@ -83,7 +83,19 @@ export default class TrayComponent extends Component {
 
   @action
   toggleBodyScroll(target, [isClosed]) {
-    if (this.args.preventScroll && !this.args.embed) {
+    this.toggleBodyScrollTask.perform(target, isClosed);
+  }
+
+  @task({ enqueue: true })
+  *toggleBodyScrollTask(target, isClosed) {
+    if (
+      this.args.preventScroll &&
+      !this.args.embed &&
+      typeof FastBoot === 'undefined'
+    ) {
+      let { disableBodyScroll, enableBodyScroll } = yield import(
+        'body-scroll-lock'
+      );
       if (isClosed) {
         enableBodyScroll(target);
       } else {

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,6 +2,11 @@
 
 module.exports = {
   name: require('./package').name,
+  options: {
+    babel: {
+      plugins: [require.resolve('ember-auto-import/babel-plugin')],
+    },
+  },
 
   included() {
     let app = this._findHost();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,8 @@ importers:
       ember-cli: 4.7.0
       ember-cli-babel: 7.26.11
       ember-cli-dependency-checker: 3.3.1
+      ember-cli-fastboot: ^3.3.2
+      ember-cli-fastboot-testing: ^0.6.0
       ember-cli-htmlbars: 6.1.1
       ember-cli-inject-live-reload: 2.1.0
       ember-cli-sass: 11.0.1
@@ -233,6 +235,8 @@ importers:
       ember-cli: 4.7.0
       ember-cli-babel: 7.26.11
       ember-cli-dependency-checker: 3.3.1_ember-cli@4.7.0
+      ember-cli-fastboot: 3.3.2
+      ember-cli-fastboot-testing: 0.6.0_webpack@5.74.0
       ember-cli-htmlbars: 6.1.1
       ember-cli-inject-live-reload: 2.1.0
       ember-cli-sass: 11.0.1
@@ -2459,8 +2463,30 @@ packages:
       config-chain: 1.1.13
     dev: true
 
+  /@simple-dom/document/1.4.0:
+    resolution: {integrity: sha512-/RUeVH4kuD3rzo5/91+h4Z1meLSLP66eXqpVAw/4aZmYozkeqUkMprq0znL4psX/adEed5cBgiNJcfMz/eKZLg==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+    dev: true
+
   /@simple-dom/interface/1.4.0:
     resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
+    dev: true
+
+  /@simple-dom/parser/1.4.0:
+    resolution: {integrity: sha512-TNjDkOehueRIKr1df416qk9ELj+qWuVVJNIT25y1aZg3pQvxv4UPGrgaDFte7dsWBTbF3V8NYPNQ5FDUZQ8Wlg==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+    dev: true
+
+  /@simple-dom/serializer/1.4.0:
+    resolution: {integrity: sha512-mI1yRahsVs8atXLiQksineDsFEFqeG7RHwnnBTDOK6inbzl4tZQgjR+Z7edjgIJq5j5RhZvwPI6EuCji9B3eQw==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+    dev: true
+
+  /@simple-dom/void-map/1.4.0:
+    resolution: {integrity: sha512-VDhLEyVCbuhOBBgHol9ShzIv9O8UCzdXeH4FoXu2DOcu/nnvTjLTck+BgXsCLv5ynDiUdoqsREEVFnoyPpFKVw==}
     dev: true
 
   /@sindresorhus/is/0.14.0:
@@ -4479,6 +4505,10 @@ packages:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     dev: true
 
+  /blueimp-md5/2.19.0:
+    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+    dev: true
+
   /bn.js/4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
     dev: true
@@ -5206,6 +5236,28 @@ packages:
       rsvp: 3.6.2
       sri-toolbox: 0.2.0
       symlink-or-copy: 1.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /broccoli-stew/1.6.0:
+    resolution: {integrity: sha512-sUwCJNnYH4Na690By5xcEMAZqKgquUQnMAEuIiL3Z2k63mSw9Xg+7Ew4wCrFrMmXMcLpWjZDOm6Yqnq268N+ZQ==}
+    engines: {node: ^4.5 || 6.* || >= 7.*}
+    dependencies:
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 2.0.2
+      broccoli-merge-trees: 2.0.1
+      broccoli-persistent-filter: 1.4.6
+      broccoli-plugin: 1.3.1
+      chalk: 2.4.2
+      debug: 3.2.7
+      ensure-posix-path: 1.1.1
+      fs-extra: 5.0.0
+      minimatch: 3.1.2
+      resolve: 1.22.1
+      rsvp: 4.8.5
+      symlink-or-copy: 1.3.1
+      walk-sync: 0.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7002,7 +7054,7 @@ packages:
       semver: 6.3.0
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: true
 
   /electron-to-chromium/1.4.241:
@@ -7407,6 +7459,56 @@ packages:
       silent-error: 1.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /ember-cli-fastboot-testing/0.6.0_webpack@5.74.0:
+    resolution: {integrity: sha512-ppZyrb4qKjaF+JqsHgDtSic04V5Ut4i1z3FkT2n0IizzL1duQN3rqQgE0sKa8wR7B4tBd7Fc+JQL3VIkVwzBow==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      body-parser: 1.20.0
+      ember-auto-import: 2.4.2_webpack@5.74.0
+      ember-cli-babel: 7.26.11
+      fastboot: 3.3.2
+      json-fn: 1.1.1
+      minimist: 1.2.6
+      nock: 13.2.9
+      resolve: 1.22.1
+      whatwg-fetch: 3.6.2
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+      - webpack
+    dev: true
+
+  /ember-cli-fastboot/3.3.2:
+    resolution: {integrity: sha512-3nPyXapAv9SwCV6KVdSg9CdjMtONkb5V8VZJiWTNMowu1HiODO5HUykaAd0niH94qnJivdpbH544S3g0TZ+Jfw==}
+    engines: {node: 12.* || 14.* || >=16}
+    dependencies:
+      broccoli-concat: 4.2.5
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      chalk: 4.1.2
+      ember-cli-babel: 7.26.11
+      ember-cli-lodash-subset: 2.0.1
+      ember-cli-preprocess-registry: 3.3.0
+      ember-cli-version-checker: 5.1.2
+      fastboot: 3.3.2
+      fastboot-express-middleware: 3.3.2
+      fastboot-transform: 0.1.3
+      fs-extra: 10.1.0
+      json-stable-stringify: 1.0.1
+      md5-hex: 3.0.1
+      recast: 0.19.1
+      silent-error: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /ember-cli-get-component-path-option/1.0.0:
@@ -9295,6 +9397,46 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /fastboot-express-middleware/3.3.2:
+    resolution: {integrity: sha512-/Fgr29Q1bMDiv65BeCYmFR88otTg9QJYvmVIWrgkwWSkfya5h1XzCQYEz+VqyhWT1v+BQWq98SuyKfpNrL2cRA==}
+    engines: {node: 12.* || 14.* || >=16}
+    dependencies:
+      chalk: 4.1.2
+      fastboot: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /fastboot-transform/0.1.3:
+    resolution: {integrity: sha512-6otygPIJw1ARp1jJb+6KVO56iKBjhO+5x59RSC9qiZTbZRrv+HZAuP00KD3s+nWMvcFDemtdkugki9DNFTTwCQ==}
+    dependencies:
+      broccoli-stew: 1.6.0
+      convert-source-map: 1.8.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /fastboot/3.3.2:
+    resolution: {integrity: sha512-2NKTW32GvEsDyBrdw1trW1JsbS+9/7sAQuKwkht12mNitimRrSKVLP2AxsM/HSXQE+aiET4XCfKdyeIy0kQbKQ==}
+    engines: {node: 12.* || 14.* || >=16}
+    dependencies:
+      chalk: 4.1.2
+      cookie: 0.4.2
+      debug: 4.3.4
+      jsdom: 19.0.0
+      resolve: 1.22.1
+      simple-dom: 1.4.0
+      source-map-support: 0.5.21
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
@@ -10265,7 +10407,7 @@ packages:
     dev: true
 
   /hawk/1.1.1:
-    resolution: {integrity: sha512-am8sVA2bCJIw8fuuVcKvmmNnGFUGW8spTkVtj2fXTEZVkfN42bwFZFtDem57eFi+NSxurJB8EQ7Jd3uCHLn8Vw==}
+    resolution: {integrity: sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=}
     engines: {node: '>=0.8.0'}
     deprecated: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
     requiresBuild: true
@@ -11169,6 +11311,48 @@ packages:
       esprima: 4.0.1
     dev: true
 
+  /jsdom/19.0.0:
+    resolution: {integrity: sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.8.0
+      acorn-globals: 6.0.0
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.4.0
+      domexception: 4.0.0
+      escodegen: 2.0.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.2
+      parse5: 6.0.1
+      saxes: 5.0.1
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.2
+      w3c-hr-time: 1.0.2
+      w3c-xmlserializer: 3.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 10.0.0
+      ws: 8.8.1
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /jsdom/20.0.0:
     resolution: {integrity: sha512-x4a6CKCgx00uCmP+QakBDFXwjAJ69IkkIWHmtmjd3wvXPcdOS44hfX2vqkOQrVrq8l9DhNNADZRXaCEWvgXtVA==}
     engines: {node: '>=14'}
@@ -11242,6 +11426,10 @@ packages:
 
   /json-buffer/3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
+  /json-fn/1.1.1:
+    resolution: {integrity: sha512-diGeurhgiazd1lfByjn83uQkF6fVFdiCiQgJyhN3/aCl7EKye0aZe3r9eeQPKcsCh81Mntrvt46z65cn7ZwZHA==}
     dev: true
 
   /json-parse-better-errors/1.0.2:
@@ -11929,6 +12117,13 @@ packages:
       '@types/minimatch': 3.0.5
       minimatch: 3.1.2
 
+  /md5-hex/3.0.1:
+    resolution: {integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==}
+    engines: {node: '>=8'}
+    dependencies:
+      blueimp-md5: 2.19.0
+    dev: true
+
   /md5.js/1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
     dependencies:
@@ -11981,7 +12176,7 @@ packages:
     dev: true
 
   /media-typer/0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
     dev: true
 
@@ -12594,6 +12789,18 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.4.0
+    dev: true
+
+  /nock/13.2.9:
+    resolution: {integrity: sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==}
+    engines: {node: '>= 10.13'}
+    dependencies:
+      debug: 4.3.4
+      json-stringify-safe: 5.0.1
+      lodash: 4.17.21
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /node-domexception/1.0.0:
@@ -13762,6 +13969,11 @@ packages:
     engines: {node: 10.* || >= 12.*}
     dev: true
 
+  /propagate/2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /proper-lockfile/4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
     dependencies:
@@ -14080,6 +14292,16 @@ packages:
       esprima: 4.0.1
       private: 0.1.8
       source-map: 0.6.1
+
+  /recast/0.19.1:
+    resolution: {integrity: sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==}
+    engines: {node: '>= 4'}
+    dependencies:
+      ast-types: 0.13.3
+      esprima: 4.0.1
+      private: 0.1.8
+      source-map: 0.6.1
+    dev: true
 
   /rechoir/0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
@@ -14648,6 +14870,13 @@ packages:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
     dev: true
 
+  /saxes/5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
+    dependencies:
+      xmlchars: 2.2.0
+    dev: true
+
   /saxes/6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -14853,6 +15082,16 @@ packages:
       debug: 2.6.9
     transitivePeerDependencies:
       - supports-color
+
+  /simple-dom/1.4.0:
+    resolution: {integrity: sha512-TnBPkmOyjdaOqyBMb4ick+n8c0Xv9Iwg1PykFV7hz9Se3UCiacTbRb+25cPmvozFNJLBUNvUzX/KsPfXF14ivA==}
+    dependencies:
+      '@simple-dom/document': 1.4.0
+      '@simple-dom/interface': 1.4.0
+      '@simple-dom/parser': 1.4.0
+      '@simple-dom/serializer': 1.4.0
+      '@simple-dom/void-map': 1.4.0
+    dev: true
 
   /simple-html-tokenizer/0.5.11:
     resolution: {integrity: sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==}
@@ -16595,6 +16834,14 @@ packages:
   /whatwg-mimetype/3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-url/10.0.0:
+    resolution: {integrity: sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==}
+    engines: {node: '>=12'}
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
     dev: true
 
   /whatwg-url/11.0.0:

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -1,3 +1,13 @@
-{{page-title "ember-mobile-menu test-app"}}
+{{!page-title "ember-mobile-menu test-app"}}
 
-{{outlet}}
+<MobileMenuWrapper as |mmw|>
+  <mmw.MobileMenu data-test-menu as |mm|>
+    <mm.LinkTo @route="index">Home</mm.LinkTo>
+  </mmw.MobileMenu>
+
+  <mmw.Content>
+    <mmw.Toggle data-test-menu-toggle>Menu</mmw.Toggle>
+
+    {{outlet}}
+  </mmw.Content>
+</MobileMenuWrapper>

--- a/test-app/config/targets.js
+++ b/test-app/config/targets.js
@@ -8,4 +8,5 @@ const browsers = [
 
 module.exports = {
   browsers,
+  node: 'current',
 };

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -38,6 +38,8 @@
     "ember-cli": "4.7.0",
     "ember-cli-babel": "7.26.11",
     "ember-cli-dependency-checker": "3.3.1",
+    "ember-cli-fastboot": "^3.3.2",
+    "ember-cli-fastboot-testing": "^0.6.0",
     "ember-cli-htmlbars": "6.1.1",
     "ember-cli-inject-live-reload": "2.1.0",
     "ember-cli-sass": "11.0.1",

--- a/test-app/tests/fastboot/index-test.js
+++ b/test-app/tests/fastboot/index-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import {
+  setup,
+  visit /* mockServer */,
+} from 'ember-cli-fastboot-testing/test-support';
+
+module('FastBoot | index', function (hooks) {
+  setup(hooks);
+
+  test('it renders a page...', async function (assert) {
+    await visit('/');
+
+    // smoke test
+    assert.dom('[data-test-menu]').exists();
+    assert.dom('[data-test-menu-toggle]').exists();
+  });
+});


### PR DESCRIPTION
Unfortunately the body-scroll-lock library that we use only checks `typeof window === 'undefined'` before trying to add event listeners. In Fastboot this is not the case, yet `addEventListener` is not available.

Apart from adding a smoke test for fastboot support, this fixes fastboot compatibility by dynamically importing `body-scroll-lock` in non-fastboot environments.

Soon we will be able to migrate to https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior once Safari 16 gets released/adopted and get rid of the library altogether.