### PR TITLE
Set correct supported ember-source as peerDependency

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -62,7 +62,7 @@
     "webpack": "5.82.1"
   },
   "peerDependencies": {
-    "ember-source": "*"
+    "ember-source": ">=3.28.0"
   },
   "engines": {
     "node": "14.* || >= 16"


### PR DESCRIPTION
We were allowing all ember-source, but our support-matrix specified 3.28+. This PR sets the correct minimum version.