### PR TITLE
Specify ember-source >=v4 as a peer dependency

### DIFF
--- a/ember-mobile-menu/package.json
+++ b/ember-mobile-menu/package.json
@@ -77,6 +77,9 @@
     "rollup": "3.29.4",
     "rollup-plugin-copy": "3.5.0"
   },
+  "peerDependencies": {
+    "ember-source": ">=4.0.0"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       ember-set-body-class:
         specifier: ^1.0.1
         version: 1.0.2
+      ember-source:
+        specifier: '>=4.0.0'
+        version: 5.4.0(@babel/core@7.23.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.89.0)
       tracked-built-ins:
         specifier: ^3.0.0
         version: 3.3.0


### PR DESCRIPTION
We already dropped support for ember-source <4, this just enforces it through a peer dependency.