### PR TITLE
Make tracked-built-ins a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Requirements
 * Ember.js v4.0 or above
 * Ember CLI v3.12 or above
 * ember-concurrency v3.x
+* tracked-built-ins v3.x
 * ember-auto-import v2.x
 
 **NOTE:** This addon utilizes ResizeObservers. If you require support for older browser you can install a ResizeObserver polyfill like [ember-resize-observer-polyfill](https://github.com/PrecisionNutrition/ember-resize-observer-polyfill).

--- a/docs/package.json
+++ b/docs/package.json
@@ -74,6 +74,7 @@
     "qunit": "2.20.0",
     "qunit-dom": "3.0.0",
     "sass": "1.69.5",
+    "tracked-built-ins": "^3.3.0",
     "webpack": "5.89.0"
   },
   "engines": {

--- a/ember-mobile-menu/package.json
+++ b/ember-mobile-menu/package.json
@@ -52,7 +52,6 @@
     "ember-gesture-modifiers": "^5.0.0",
     "ember-on-resize-modifier": "^2.0.0",
     "ember-set-body-class": "^1.0.1",
-    "tracked-built-ins": "^3.0.0",
     "wobble": "^1.5.1"
   },
   "devDependencies": {
@@ -78,7 +77,8 @@
     "rollup-plugin-copy": "3.5.0"
   },
   "peerDependencies": {
-    "ember-source": ">=4.0.0"
+    "ember-source": ">=4.0.0",
+    "tracked-built-ins": ">=3.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       sass:
         specifier: 1.69.5
         version: 1.69.5
+      tracked-built-ins:
+        specifier: ^3.3.0
+        version: 3.3.0
       webpack:
         specifier: 5.89.0
         version: 5.89.0
@@ -211,7 +214,7 @@ importers:
         specifier: '>=4.0.0'
         version: 5.4.0(@babel/core@7.23.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.89.0)
       tracked-built-ins:
-        specifier: ^3.0.0
+        specifier: '>=3.0.0'
         version: 3.3.0
       wobble:
         specifier: ^1.5.1
@@ -400,6 +403,9 @@ importers:
       sass:
         specifier: 1.69.5
         version: 1.69.5
+      tracked-built-ins:
+        specifier: ^3.3.0
+        version: 3.3.0
       webpack:
         specifier: 5.89.0
         version: 5.89.0
@@ -9174,7 +9180,6 @@ packages:
       ember-cli-htmlbars: 5.7.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /ember-truth-helpers@3.1.1:
     resolution: {integrity: sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==}
@@ -16968,7 +16973,6 @@ packages:
       ember-tracked-storage-polyfill: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /tracked-toolbox@2.0.0(ember-source@5.4.0):
     resolution: {integrity: sha512-adZtX+RGN6F+pWs/5JqVuDxLhuia4uhqmQp+UlUaxpykWjDFETtAdQR+LdDJiFPXFAXnS6FBqn/tnSLJQCm3Yw==}

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -67,6 +67,7 @@
     "qunit": "2.20.0",
     "qunit-dom": "3.0.0",
     "sass": "1.69.5",
+    "tracked-built-ins": "^3.3.0",
     "webpack": "5.89.0"
   },
   "engines": {


### PR DESCRIPTION
This is now part of the default ember blueprint, so we can make it a peerDependency.