### PR TITLE
Implement basic scale correction for gestures

### DIFF
--- a/ember-mobile-menu/src/utils/normalize-coordinates.js
+++ b/ember-mobile-menu/src/utils/normalize-coordinates.js
@@ -22,3 +22,16 @@ export default function normalizeCoordinates(e, bcr) {
     },
   };
 }
+
+export function scaleCorrection(e, scaleX, scaleY) {
+  // TODO: convert rest of API
+  return {
+    ...e,
+    current: {
+      ...e.current,
+      distance: e.current.distance / ((scaleX + scaleY) / 2),
+      distanceX: e.current.distanceX / scaleX,
+      distanceY: e.current.distanceY / scaleY,
+    },
+  };
+}


### PR DESCRIPTION
This also fixes the issues seen with the latest version of ember-gesture-modifiers, which fixed a velocity calculation issue, but made tests break due to us not properly handling the scaled down menu.