### PR TITLE
Inline body scroll lock library, apply small fixes & (unofficial) fastboot support

### DIFF
--- a/ember-mobile-menu/package.json
+++ b/ember-mobile-menu/package.json
@@ -45,7 +45,6 @@
     "@embroider/addon-shim": "^1.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "body-scroll-lock": "^3.0.1",
     "ember-concurrency": "^3.0.0 || ^4.0.0",
     "ember-gesture-modifiers": "^5.0.0 || ^6.0.0",
     "ember-modify-based-class-resource": "^1.1.0",

--- a/ember-mobile-menu/src/components/mobile-menu/tray.js
+++ b/ember-mobile-menu/src/components/mobile-menu/tray.js
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { action } from '@ember/object';
-import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+} from '../../utils/body-scroll-lock';
 import './tray.css';
 
 /**

--- a/ember-mobile-menu/src/utils/body-scroll-lock.js
+++ b/ember-mobile-menu/src/utils/body-scroll-lock.js
@@ -1,3 +1,27 @@
+// Adopted and modified from https://github.com/willmcpo/body-scroll-lock
+
+// MIT License
+//
+// Copyright (c) 2018 Will Po
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 // Older browsers don't support event options, feature detect it.
 
 // Adopted and modified solution from Bohdan Didukh (2017)

--- a/ember-mobile-menu/src/utils/body-scroll-lock.js
+++ b/ember-mobile-menu/src/utils/body-scroll-lock.js
@@ -1,0 +1,297 @@
+// Older browsers don't support event options, feature detect it.
+
+// Adopted and modified solution from Bohdan Didukh (2017)
+// https://stackoverflow.com/questions/41594997/ios-10-safari-prevent-scrolling-behind-a-fixed-overlay-and-maintain-scroll-posi
+
+let hasPassiveEvents = false;
+if (typeof window !== 'undefined') {
+  const passiveTestOptions = {
+    get passive() {
+      hasPassiveEvents = true;
+      return undefined;
+    },
+  };
+  window.addEventListener('testPassive', null, passiveTestOptions);
+  window.removeEventListener('testPassive', null, passiveTestOptions);
+}
+
+const isIosDevice =
+  typeof window !== 'undefined' &&
+  window.navigator &&
+  window.navigator.platform &&
+  (/iP(ad|hone|od)/.test(window.navigator.platform) ||
+    (window.navigator.platform === 'MacIntel' &&
+      window.navigator.maxTouchPoints > 1));
+
+let locks = [];
+let documentListenerAdded = false;
+let initialClientY = -1;
+let previousBodyOverflowSetting;
+let previousBodyPosition;
+let previousBodyPaddingRight;
+
+// returns true if `el` should be allowed to receive touchmove events.
+const allowTouchMove = (el) =>
+  locks.some((lock) => {
+    if (lock.options.allowTouchMove && lock.options.allowTouchMove(el)) {
+      return true;
+    }
+
+    return false;
+  });
+
+const preventDefault = (rawEvent) => {
+  const e = rawEvent || window.event;
+
+  // For the case whereby consumers adds a touchmove event listener to document.
+  // Recall that we do document.addEventListener('touchmove', preventDefault, { passive: false })
+  // in disableBodyScroll - so if we provide this opportunity to allowTouchMove, then
+  // the touchmove event on document will break.
+  if (allowTouchMove(e.target)) {
+    return true;
+  }
+
+  // Do not prevent if the event has more than one touch (usually meaning this is a multi touch gesture like pinch to zoom).
+  if (e.touches.length > 1) return true;
+
+  if (e.preventDefault) e.preventDefault();
+
+  return false;
+};
+
+const setOverflowHidden = (options) => {
+  // If previousBodyPaddingRight is already set, don't set it again.
+  if (previousBodyPaddingRight === undefined) {
+    const reserveScrollBarGap =
+      !!options && options.reserveScrollBarGap === true;
+    const scrollBarGap =
+      window.innerWidth - document.documentElement.clientWidth;
+
+    if (reserveScrollBarGap && scrollBarGap > 0) {
+      const computedBodyPaddingRight = parseInt(
+        window
+          .getComputedStyle(document.body)
+          .getPropertyValue('padding-right'),
+        10,
+      );
+      previousBodyPaddingRight = document.body.style.paddingRight;
+      document.body.style.paddingRight = `${computedBodyPaddingRight + scrollBarGap}px`;
+    }
+  }
+
+  // If previousBodyOverflowSetting is already set, don't set it again.
+  if (previousBodyOverflowSetting === undefined) {
+    previousBodyOverflowSetting = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+};
+
+const restoreOverflowSetting = () => {
+  if (previousBodyPaddingRight !== undefined) {
+    document.body.style.paddingRight = previousBodyPaddingRight;
+
+    // Restore previousBodyPaddingRight to undefined so setOverflowHidden knows it
+    // can be set again.
+    previousBodyPaddingRight = undefined;
+  }
+
+  if (previousBodyOverflowSetting !== undefined) {
+    document.body.style.overflow = previousBodyOverflowSetting;
+
+    // Restore previousBodyOverflowSetting to undefined
+    // so setOverflowHidden knows it can be set again.
+    previousBodyOverflowSetting = undefined;
+  }
+};
+
+const setPositionFixed = () =>
+  window.requestAnimationFrame(() => {
+    // If previousBodyPosition is already set, don't set it again.
+    if (previousBodyPosition === undefined) {
+      previousBodyPosition = {
+        position: document.body.style.position,
+        top: document.body.style.top,
+        left: document.body.style.left,
+      };
+
+      // Update the dom inside an animation frame
+      const { scrollY, scrollX, innerHeight } = window;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `${-scrollY}px`;
+      document.body.style.left = `${-scrollX}px`;
+
+      setTimeout(
+        () =>
+          window.requestAnimationFrame(() => {
+            // Attempt to check if the bottom bar appeared due to the position change
+            const bottomBarHeight = innerHeight - window.innerHeight;
+            if (bottomBarHeight && scrollY >= innerHeight) {
+              // Move the content further up so that the bottom bar doesn't hide it
+              document.body.style.top = -(scrollY + bottomBarHeight);
+            }
+          }),
+        300,
+      );
+    }
+  });
+
+const restorePositionSetting = () => {
+  if (previousBodyPosition !== undefined) {
+    // Convert the position from "px" to Int
+    const y = -parseInt(document.body.style.top, 10);
+    const x = -parseInt(document.body.style.left, 10);
+
+    // Restore styles
+    document.body.style.position = previousBodyPosition.position;
+    document.body.style.top = previousBodyPosition.top;
+    document.body.style.left = previousBodyPosition.left;
+
+    // Restore scroll
+    window.scrollTo(x, y);
+
+    previousBodyPosition = undefined;
+  }
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
+const isTargetElementTotallyScrolled = (targetElement) =>
+  targetElement
+    ? targetElement.scrollHeight - targetElement.scrollTop <=
+      targetElement.clientHeight
+    : false;
+
+const handleScroll = (event, targetElement) => {
+  const clientY = event.targetTouches[0].clientY - initialClientY;
+
+  if (allowTouchMove(event.target)) {
+    return false;
+  }
+
+  if (targetElement && targetElement.scrollTop === 0 && clientY > 0) {
+    // element is at the top of its scroll.
+    return preventDefault(event);
+  }
+
+  if (isTargetElementTotallyScrolled(targetElement) && clientY < 0) {
+    // element is at the bottom of its scroll.
+    return preventDefault(event);
+  }
+
+  event.stopPropagation();
+  return true;
+};
+
+export const disableBodyScroll = (targetElement, options) => {
+  // targetElement must be provided
+  if (!targetElement) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'disableBodyScroll unsuccessful - targetElement must be provided when calling disableBodyScroll on IOS devices.',
+    );
+    return;
+  }
+
+  // disableBodyScroll must not have been called on this targetElement before
+  if (locks.some((lock) => lock.targetElement === targetElement)) {
+    return;
+  }
+
+  const lock = {
+    targetElement,
+    options: options || {},
+  };
+
+  locks = [...locks, lock];
+
+  if (isIosDevice) {
+    setPositionFixed();
+  } else {
+    setOverflowHidden(options);
+  }
+
+  if (isIosDevice) {
+    targetElement.ontouchstart = (event) => {
+      if (event.targetTouches.length === 1) {
+        // detect single touch.
+        initialClientY = event.targetTouches[0].clientY;
+      }
+    };
+    targetElement.ontouchmove = (event) => {
+      if (event.targetTouches.length === 1) {
+        // detect single touch.
+        handleScroll(event, targetElement);
+      }
+    };
+
+    if (!documentListenerAdded) {
+      document.addEventListener(
+        'touchmove',
+        preventDefault,
+        hasPassiveEvents ? { passive: false } : undefined,
+      );
+      documentListenerAdded = true;
+    }
+  }
+};
+
+export const clearAllBodyScrollLocks = () => {
+  if (isIosDevice) {
+    // Clear all locks ontouchstart/ontouchmove handlers, and the references.
+    locks.forEach((lock) => {
+      lock.targetElement.ontouchstart = null;
+      lock.targetElement.ontouchmove = null;
+    });
+
+    if (documentListenerAdded) {
+      document.removeEventListener(
+        'touchmove',
+        preventDefault,
+        hasPassiveEvents ? { passive: false } : undefined,
+      );
+      documentListenerAdded = false;
+    }
+
+    // Reset initial clientY.
+    initialClientY = -1;
+  }
+
+  if (isIosDevice) {
+    restorePositionSetting();
+  } else {
+    restoreOverflowSetting();
+  }
+
+  locks = [];
+};
+
+export const enableBodyScroll = (targetElement) => {
+  if (!targetElement) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'enableBodyScroll unsuccessful - targetElement must be provided when calling enableBodyScroll on IOS devices.',
+    );
+    return;
+  }
+
+  locks = locks.filter((lock) => lock.targetElement !== targetElement);
+
+  if (isIosDevice) {
+    targetElement.ontouchstart = null;
+    targetElement.ontouchmove = null;
+
+    if (documentListenerAdded && locks.length === 0) {
+      document.removeEventListener(
+        'touchmove',
+        preventDefault,
+        hasPassiveEvents ? { passive: false } : undefined,
+      );
+      documentListenerAdded = false;
+    }
+  }
+
+  if (isIosDevice) {
+    restorePositionSetting();
+  } else {
+    restoreOverflowSetting();
+  }
+};

--- a/ember-mobile-menu/src/utils/body-scroll-lock.js
+++ b/ember-mobile-menu/src/utils/body-scroll-lock.js
@@ -127,7 +127,7 @@ const setPositionFixed = () =>
             const bottomBarHeight = innerHeight - window.innerHeight;
             if (bottomBarHeight && scrollY >= innerHeight) {
               // Move the content further up so that the bottom bar doesn't hide it
-              document.body.style.top = -(scrollY + bottomBarHeight);
+              document.body.style.top = `-${scrollY + bottomBarHeight}px`;
             }
           }),
         300,

--- a/ember-mobile-menu/src/utils/body-scroll-lock.js
+++ b/ember-mobile-menu/src/utils/body-scroll-lock.js
@@ -28,7 +28,7 @@
 // https://stackoverflow.com/questions/41594997/ios-10-safari-prevent-scrolling-behind-a-fixed-overlay-and-maintain-scroll-posi
 
 let hasPassiveEvents = false;
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && typeof FastBoot === 'undefined') {
   const passiveTestOptions = {
     get passive() {
       hasPassiveEvents = true;
@@ -41,6 +41,7 @@ if (typeof window !== 'undefined') {
 
 const isIosDevice =
   typeof window !== 'undefined' &&
+  typeof FastBoot === 'undefined' &&
   window.navigator &&
   window.navigator.platform &&
   (/iP(ad|hone|od)/.test(window.navigator.platform) ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       '@glimmer/tracking':
         specifier: ^1.0.4
         version: 1.1.2
-      body-scroll-lock:
-        specifier: ^3.0.1
-        version: 3.1.5
       ember-concurrency:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.0(@babel/core@7.23.9)(@glimmer/tracking@1.1.2)
@@ -5281,6 +5278,7 @@ packages:
 
   /body-scroll-lock@3.1.5:
     resolution: {integrity: sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==}
+    dev: true
 
   /body@5.1.0:
     resolution: {integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==}


### PR DESCRIPTION
https://github.com/willmcpo/body-scroll-lock has been unmaintained for a couple of years now. There's some small bugs in there and it's breaking fastboot too. Inlining it allows us to fix these issues in a straightforward way. The library is pretty small, so this should be fine.

This (unofficially) also re-adds fastboot support since we can now modify this library in a way to make it work. Fastboot is currently incompatible with embroider optimized, so we can't add tests for it yet. This will be added later through https://github.com/nickschot/ember-mobile-menu/pull/854 .