### PR TITLE
Fixing a regression where the transitioning state was not guaranteed to be reset after transition ended

### DIFF
--- a/ember-mobile-menu/src/components/mobile-menu.js
+++ b/ember-mobile-menu/src/components/mobile-menu.js
@@ -12,29 +12,33 @@ class StateResource extends Resource {
   @tracked open = false;
   @tracked closed = true;
   @tracked dragging = false;
-  @tracked transitioning = false;
+
+  get transitioning() {
+    return !this.dragging && !this.open && !this.closed;
+  }
 
   modify([position, isDragging, width, onToggle]) {
     this.dragging = position !== 0 && isDragging;
     let open = !this.dragging && Math.abs(position) === width;
     let closed = !this.dragging && position === 0;
-    next(() => {
-      this.maybeToggle(open, closed, onToggle);
-    });
-    this.transitioning = !this.dragging && !this.open && !this.closed;
+    this.maybeToggle(open, closed, onToggle);
   }
 
   maybeToggle(open, closed, onToggle) {
     if (this.open !== open) {
-      this.open = open;
-      if (open) {
-        onToggle(true);
-      }
+      next(() => {
+        this.open = open;
+        if (open) {
+          onToggle(true);
+        }
+      });
     } else if (this.closed !== closed) {
-      this.closed = closed;
-      if (closed) {
-        onToggle(false);
-      }
+      next(() => {
+        this.closed = closed;
+        if (closed) {
+          onToggle(false);
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
Okay, so I encountered a bug where the transitioning state was not guaranteed to be set to false when the transition ended.

It turns out [I introduced the bug myself](https://github.com/nickschot/ember-mobile-menu/pull/798/files#diff-c78bbbda25290d63ca17156d8acede033f841b28a0c1c3f13700b53ef4ce0d08L39)🙈

In v4.0.0, the toggling of  `this.open` and `this.closed` inside `maybeToggle` was guaranteed to run before [this.transitioning was set](https://github.com/nickschot/ember-mobile-menu/pull/798/files#diff-c78bbbda25290d63ca17156d8acede033f841b28a0c1c3f13700b53ef4ce0d08L40).

With my PR to v5.0.0, the assignments of this.closed and this.open were moved inside the next loop (because of the classic `You attempted to update … but it had already been used previously in the same computation.` without ensuring that this.transitioning was uptated after that.

This regression-fix-PR is a conservative fix that should back to the old timing. Alternative approaches could be to keep `@tracked transitioning` and set transitioning explicitly inside the maybeToggle function (to ensure it is run after the assignments to this.open and this.closed). Other ideas may be to refactor away from the next-pattern altogether, also perhaps use a function based resource. 