### PR TITLE
Drop support for ember-source @ 3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
@@ -70,8 +69,6 @@ jobs:
           - ember-lts-5.8
           - ember-lts-5.12
           - ember-release
-          - ember-classic
-          - ember-default-with-jquery
           - embroider-safe
           - embroider-optimized
 

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -8,18 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-cli': '~4.12.0',
-            'ember-source': '~3.28.0',
-            'ember-resolver': '^8.0.0',
-            'ember-load-initializers': '^2.1.2',
-            '@ember/test-helpers': '^2.0.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {
@@ -94,44 +82,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
-      {
-        name: 'ember-default-with-jquery',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-cli': '~4.12.0',
-            'ember-source': '~3.28.0',
-            '@ember/jquery': '^1.1.0',
-            'ember-resolver': '^10.0.0',
-            'ember-load-initializers': '^2.1.2',
-          },
-        },
-      },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-cli': '~4.12.0',
-            'ember-source': '~3.28.0',
-            'ember-resolver': '^10.0.0',
-            'ember-load-initializers': '^2.1.2',
-          },
-          ember: {
-            edition: 'classic',
           },
         },
       },


### PR DESCRIPTION
also, we don't need to test ember-classic or ember + jquery

This should help get CI passing over here:
- https://github.com/nickschot/ember-mobile-menu/pull/1156