### PR TITLE
Remove @ember/render-modifiers

### DIFF
--- a/ember-mobile-menu/package.json
+++ b/ember-mobile-menu/package.json
@@ -42,7 +42,6 @@
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
   },
   "dependencies": {
-    "@ember/render-modifiers": "^2.0.0 || ^3.0.0",
     "@ember/test-waiters": "^3.0.0 || ^4.0.0",
     "@embroider/addon-shim": "^1.8.9",
     "decorator-transforms": "^2.2.2",

--- a/ember-mobile-menu/package.json
+++ b/ember-mobile-menu/package.json
@@ -47,6 +47,7 @@
     "decorator-transforms": "^2.2.2",
     "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-concurrency": "^3.0.0 || ^4.0.0",
+    "ember-modifier": "^4.2.2",
     "ember-gesture-modifiers": "^5.0.0 || ^6.0.0",
     "ember-on-resize-modifier": "^2.0.0",
     "ember-set-body-class": "^1.0.1",

--- a/ember-mobile-menu/package.json
+++ b/ember-mobile-menu/package.json
@@ -94,7 +94,8 @@
       "./components/mobile-menu-wrapper/content.js": "./dist/_app_/components/mobile-menu-wrapper/content.js",
       "./components/mobile-menu.js": "./dist/_app_/components/mobile-menu.js",
       "./components/mobile-menu/mask.js": "./dist/_app_/components/mobile-menu/mask.js",
-      "./components/mobile-menu/tray.js": "./dist/_app_/components/mobile-menu/tray.js"
+      "./components/mobile-menu/tray.js": "./dist/_app_/components/mobile-menu/tray.js",
+      "./components/utils.js": "./dist/_app_/components/utils.js"
     }
   }
 }

--- a/ember-mobile-menu/src/components/mobile-menu-wrapper.gjs
+++ b/ember-mobile-menu/src/components/mobile-menu-wrapper.gjs
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import { modifier as eModifier } from 'ember-modifier';
 import { action } from '@ember/object';
 import { TrackedSet } from 'tracked-built-ins';
 
@@ -15,8 +16,6 @@ import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
 import Spring from '../spring.js';
 import './mobile-menu-wrapper.css';
-// eslint-disable-next-line ember/no-at-ember-render-modifiers
-import didInsert from '@ember/render-modifiers/modifiers/did-insert';
 import onResize from 'ember-on-resize-modifier/modifiers/on-resize';
 import setBodyClass from 'ember-set-body-class/helpers/set-body-class';
 import { hash } from '@ember/helper';
@@ -442,12 +441,6 @@ export default class MobileMenuWrapper extends Component {
   scaleY = 1;
 
   @action
-  onInsert(element) {
-    this.boundingClientRect = element.getBoundingClientRect();
-    this.updateScale(element);
-  }
-
-  @action
   onResize({ target }) {
     this.boundingClientRect = target.getBoundingClientRect();
     this.updateScale(target);
@@ -474,6 +467,11 @@ export default class MobileMenuWrapper extends Component {
     return window.innerWidth;
   }
 
+  updateBounds = eModifier((element) => {
+    this.boundingClientRect = element.getBoundingClientRect();
+    this.updateScale(element);
+  });
+
   <template>
     {{#if this.preventBodyScroll}}
       {{setBodyClass "mobile-menu--prevent-scroll"}}
@@ -482,7 +480,7 @@ export default class MobileMenuWrapper extends Component {
     <div
       class="mobile-menu-wrapper
         {{if this.embed 'mobile-menu-wrapper--embedded'}}"
-      {{didInsert this.onInsert}}
+      {{this.updateBounds}}
       {{onResize this.onResize}}
       ...attributes
     >

--- a/ember-mobile-menu/src/components/mobile-menu.gjs
+++ b/ember-mobile-menu/src/components/mobile-menu.gjs
@@ -3,12 +3,11 @@ import { action } from '@ember/object';
 import { cached, tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { htmlSafe } from '@ember/template';
-import { next } from '@ember/runloop';
 import './mobile-menu.css';
 import { registerDestructor } from '@ember/destroyable';
 import MaskComponent from './mobile-menu/mask.gjs';
 import TrayComponent from './mobile-menu/tray.gjs';
-import { fn, hash } from '@ember/helper';
+import { hash } from '@ember/helper';
 import { effect } from './utils.js';
 
 const _fn = function () {};
@@ -35,8 +34,8 @@ class StateResource {
     this._dragging = position !== 0 && isDragging;
     let open = !this._dragging && Math.abs(position) === width;
     let closed = !this._dragging && position === 0;
-    // eslint-disable-next-line ember/no-runloop
-    next(() => {
+
+    effect(() => {
       this.maybeToggle(open, closed, onToggle);
     });
     this._transitioning = !this._dragging && !this._open && !this._closed;
@@ -65,14 +64,8 @@ class StateResource {
   maybeToggle(open, closed, onToggle) {
     if (this._open !== open) {
       this._open = open;
-      if (open) {
-        onToggle(true);
-      }
     } else if (this.closed !== closed) {
       this._closed = closed;
-      if (closed) {
-        onToggle(false);
-      }
     }
   }
 }
@@ -333,6 +326,8 @@ export default class MobileMenu extends Component {
     } else {
       this.close(animate);
     }
+
+    this.onToggle(open);
   }
 
   @action
@@ -350,10 +345,10 @@ export default class MobileMenu extends Component {
 
   <template>
     {{#if this.renderMenu}}
-      {{effect (fn @register this)}}
-      {{effect (fn this.openOrClose @isOpen)}}
-      {{effect this.setRendered}}
+      {{effect @register this}}
+      {{effect this.openOrClose @isOpen}}
       {{effect this.close this.type}}
+      {{effect this.setRendered}}
 
       <div
         class={{this.classNames}}

--- a/ember-mobile-menu/src/components/mobile-menu.gjs
+++ b/ember-mobile-menu/src/components/mobile-menu.gjs
@@ -29,14 +29,14 @@ class StateResource {
 
   @cached
   get current() {
-    let [position, isDragging, width, onToggle] = this._useState();
+    let [position, isDragging, width] = this._useState();
 
     this._dragging = position !== 0 && isDragging;
     let open = !this._dragging && Math.abs(position) === width;
     let closed = !this._dragging && position === 0;
 
     effect(() => {
-      this.maybeToggle(open, closed, onToggle);
+      this.maybeToggle(open, closed);
     });
     this._transitioning = !this._dragging && !this._open && !this._closed;
 
@@ -61,7 +61,7 @@ class StateResource {
     return this.current.transitioning;
   }
 
-  maybeToggle(open, closed, onToggle) {
+  maybeToggle(open, closed) {
     if (this._open !== open) {
       this._open = open;
     } else if (this.closed !== closed) {
@@ -81,7 +81,6 @@ export default class MobileMenu extends Component {
     this.position,
     this.args.isDragging,
     this._width,
-    this.onToggle,
   ]);
 
   /**

--- a/ember-mobile-menu/src/components/mobile-menu/tray.gjs
+++ b/ember-mobile-menu/src/components/mobile-menu/tray.gjs
@@ -6,10 +6,6 @@ import {
   enableBodyScroll,
 } from '../../utils/body-scroll-lock.js';
 import './tray.css';
-// eslint-disable-next-line ember/no-at-ember-render-modifiers
-import willDestroy from '@ember/render-modifiers/modifiers/will-destroy';
-// eslint-disable-next-line ember/no-at-ember-render-modifiers
-import didUpdate from '@ember/render-modifiers/modifiers/did-update';
 import didPan from 'ember-gesture-modifiers/modifiers/did-pan';
 
 /**

--- a/ember-mobile-menu/src/components/mobile-menu/tray.gjs
+++ b/ember-mobile-menu/src/components/mobile-menu/tray.gjs
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { action } from '@ember/object';
+import { modifier as eModifier } from 'ember-modifier';
 import {
   disableBodyScroll,
   enableBodyScroll,
@@ -86,16 +87,23 @@ export default class TrayComponent extends Component {
     return htmlSafe(style);
   }
 
-  @action
-  toggleBodyScroll(target, [isClosed]) {
-    if (this.args.preventScroll && !this.args.embed) {
+  lockBodyScroll = eModifier((element) => {
+    let { isClosed, preventScroll, embed } = this.args.isClosed;
+
+    if (preventScroll && !embed) {
       if (isClosed) {
-        enableBodyScroll(target);
+        enableBodyScroll(element);
       } else {
-        disableBodyScroll(target);
+        disableBodyScroll(element);
       }
     }
-  }
+
+    return () => {
+      if (preventScroll && !embed) {
+        enableBodyScroll(element);
+      }
+    };
+  });
 
   <template>
     <div
@@ -108,8 +116,7 @@ export default class TrayComponent extends Component {
         capture=@capture
         preventScroll=@preventScroll
       }}
-      {{didUpdate this.toggleBodyScroll @isClosed}}
-      {{willDestroy this.toggleBodyScroll true}}
+      {{this.lockBodyScroll}}
       ...attributes
     >
       {{yield}}

--- a/ember-mobile-menu/src/components/mobile-menu/tray.gjs
+++ b/ember-mobile-menu/src/components/mobile-menu/tray.gjs
@@ -88,7 +88,7 @@ export default class TrayComponent extends Component {
   }
 
   lockBodyScroll = eModifier((element) => {
-    let { isClosed, preventScroll, embed } = this.args.isClosed;
+    let { isClosed, preventScroll, embed } = this.args;
 
     if (preventScroll && !embed) {
       if (isClosed) {

--- a/ember-mobile-menu/src/components/mobile-menu/tray.gjs
+++ b/ember-mobile-menu/src/components/mobile-menu/tray.gjs
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
-import { action } from '@ember/object';
 import { modifier as eModifier } from 'ember-modifier';
 import {
   disableBodyScroll,

--- a/ember-mobile-menu/src/components/utils.js
+++ b/ember-mobile-menu/src/components/utils.js
@@ -4,11 +4,18 @@ import { waitForPromise } from '@ember/test-waiters';
  *
  * This version ties in to the waiter system
  */
-export function effect(fn) {
+export function effect(fn, ...args) {
   waitForPromise(
     (async () => {
+      /**
+       * Detaches from auto-tracking so that mutations here doen't cause
+       * infinite re-render loops (which would run this effect)
+       *
+       * Infinite re-render loops are still possible if then some other effect
+       * causes this effect to change.
+       */
       await 0;
-      await fn();
+      await fn(...args);
     })(),
   );
 

--- a/ember-mobile-menu/src/components/utils.js
+++ b/ember-mobile-menu/src/components/utils.js
@@ -1,0 +1,16 @@
+import { waitForPromise } from '@ember/test-waiters';
+/**
+ * See also: https://reactive.nullvoxpopuli.com/functions/sync.sync.html
+ *
+ * This version ties in to the waiter system
+ */
+export function effect(fn) {
+  waitForPromise(
+    (async () => {
+      await 0;
+      await fn();
+    })(),
+  );
+
+  return;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,9 +182,6 @@ importers:
 
   ember-mobile-menu:
     dependencies:
-      '@ember/render-modifiers':
-        specifier: ^2.0.0 || ^3.0.0
-        version: 3.0.0(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5))
       '@ember/test-waiters':
         specifier: ^3.0.0 || ^4.0.0
         version: 3.1.0
@@ -203,6 +200,9 @@ importers:
       ember-gesture-modifiers:
         specifier: ^5.0.0 || ^6.0.0
         version: 6.1.0(@babel/core@7.27.1)(@ember/test-helpers@5.2.2(@babel/core@7.27.1))(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5))
+      ember-modifier:
+        specifier: ^4.2.2
+        version: 4.2.2(@babel/core@7.27.1)
       ember-on-resize-modifier:
         specifier: ^2.0.0
         version: 2.0.2(@babel/core@7.27.1)
@@ -348,6 +348,9 @@ importers:
       ember-fetch:
         specifier: 8.1.2
         version: 8.1.2(encoding@0.1.13)
+      ember-functions-as-helper-polyfill:
+        specifier: ^2.1.3
+        version: 2.1.3(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5))
       ember-load-initializers:
         specifier: 3.0.1
         version: 3.0.1(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5))
@@ -1209,16 +1212,6 @@ packages:
     peerDependencies:
       '@glint/template': ^1.0.2
       ember-source: ^3.8 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      '@glint/template':
-        optional: true
-
-  '@ember/render-modifiers@3.0.0':
-    resolution: {integrity: sha512-gJztS8dI7Jt8ohFQptEDJAgpl9DG84IpqwQoR1JDpVIBy2uLbf8KFD6S3h3LfyMsgJce6G38cOvyQv6BDgcnsA==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@glint/template': ^1.0.2
-      ember-source: '>= 4.0.0'
     peerDependenciesMeta:
       '@glint/template':
         optional: true
@@ -10067,16 +10060,6 @@ snapshots:
       ember-source: 6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
-
-  '@ember/render-modifiers@3.0.0(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5))':
-    dependencies:
-      '@babel/core': 7.27.1
-      '@embroider/macros': 1.17.3
-      ember-cli-babel: 8.2.0(@babel/core@7.27.1)
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.27.1)
-      ember-source: 6.4.0(@glimmer/component@1.1.2(@babel/core@7.27.1))(rsvp@4.8.5)
-    transitivePeerDependencies:
       - supports-color
 
   '@ember/string@4.0.1': {}

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -48,6 +48,7 @@
     "ember-cli-sri": "2.1.1",
     "ember-cli-terser": "4.0.2",
     "ember-fetch": "8.1.2",
+    "ember-functions-as-helper-polyfill": "^2.1.3",
     "ember-load-initializers": "3.0.1",
     "ember-mobile-menu": "workspace:*",
     "ember-modifier": "4.2.2",

--- a/test-app/tests/integration/components/mobile-menu-wrapper-test.js
+++ b/test-app/tests/integration/components/mobile-menu-wrapper-test.js
@@ -397,7 +397,11 @@ module('Integration | Component | mobile-menu-wrapper', function (hooks) {
   test('it opens/closes the menu according to the @isOpen argument and calls the accompanying @onToggle hook', async function (assert) {
     this.set('isOpen', true);
     this.set('onToggle', (isOpen) => {
-      assert.strictEqual(this.isOpen, isOpen);
+      assert.strictEqual(
+        this.isOpen,
+        isOpen,
+        `onToggle called with the same value (${isOpen}) is this.isOpen (${this.isOpen})`,
+      );
     });
 
     await render(hbs`


### PR DESCRIPTION
should be non-breaking, implementation details only are changing

_however_

This does now require `ember-functions-as-helper-polyfill` for ember users using < 4.5
(I misremembered in the commit)