### PR TITLE
Deprecate decorator syntax of ember-concurrency 

### DIFF
--- a/ember-mobile-menu/package.json
+++ b/ember-mobile-menu/package.json
@@ -46,7 +46,7 @@
     "@embroider/addon-shim": "^1.8.9",
     "decorator-transforms": "^2.2.2",
     "ember-cached-decorator-polyfill": "^1.0.2",
-    "ember-concurrency": "^4.0.0",
+    "ember-concurrency": "^3.0.0 || ^4.0.0",
     "ember-modifier": "^4.2.2",
     "ember-gesture-modifiers": "^5.0.0 || ^6.0.0",
     "ember-on-resize-modifier": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,7 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@babel/core@7.28.0)(ember-source@6.5.0(@glimmer/component@1.1.2(@babel/core@7.28.0))(rsvp@4.8.5))
       ember-concurrency:
-        specifier: ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0
         version: 4.0.4(@babel/core@7.28.0)
       ember-gesture-modifiers:
         specifier: ^5.0.0 || ^6.0.0


### PR DESCRIPTION
Using task() in any form other than `taskName = task(async () => {})` is deprecated by ember-concurrency, see https://github.com/machty/ember-concurrency/pull/592/files